### PR TITLE
docs: add important notice about streaming results in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ A powerful Obsidian plugin that integrates AI-powered text processing directly i
 ## 📋 Changelog
 For detailed changes, see [CHANGELOG.md](CHANGELOG.md).
 
+> ⚠️ **ATTENTION!** 
+> Since version __0.3.0__, to view streaming results, you need to __disable__ the "Development mode -> __Use native fetch__" setting.
+
 ## Demo
 ![Demo0](docs/QuickPrompt0.gif)
 ![Demo1](docs/QuickPrompt1.gif)


### PR DESCRIPTION
Add warning about needing to disable "Use native fetch" setting for streaming results to work in version 0.3.0+